### PR TITLE
Add missing future keyword imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,6 +663,7 @@ messages[message] {
 }
 
 # Alternatively
+import future.keywords
 
 messages[message] {
     some topic in input.topics
@@ -691,6 +692,8 @@ For any applicable sequence of values, sets have the following benefits over arr
 
 **Avoid**
 ```rego
+import future.keywords
+
 required_roles := ["accountant", "reports-writer"]
 provided_roles := [role | some role in input.user.roles]
 
@@ -703,6 +706,8 @@ allow {
 
 **Prefer**
 ```rego
+import future.keywords
+
 required_roles := {"accountant", "reports-writer"}
 provided_roles := {role | some role in input.user.roles}
 


### PR DESCRIPTION
Noticed that `import future.keywords` was missing in a few places