### PR TITLE
Fix snake_case section link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and see the changelog for updates since your last visit.
   - [Get to know the built-in functions](#get-to-know-the-built-in-functions)
   - [Consider using JSON schemas for type checking](#consider-using-json-schemas-for-type-checking)
 - [Style](#style)
-  - [Prefer snake_case for rule names and variables](#prefer-snakecase-for-rule-names-and-variables)
+  - [Prefer snake_case for rule names and variables](#prefer-snake_case-for-rule-names-and-variables)
   - [Keep line length <= 120 characters](#keep-line-length--120-characters)
 - [Rules](#rules)
   - [Use helper rules and functions](#use-helper-rules-and-functions)


### PR DESCRIPTION
I noticed that the link to the `Prefer snake_case for rule names and variables` section wasn't working. Changed the link reference to `#prefer-snake_case-for-rule-names-and-variables`.