### PR TITLE
Use new future keywords in examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 Note that since this is just a document of recommendations, semantic versioning is not used here.
 Versions are only used to keep track of changes from one version to another.
 
+## [0.2.0]
+### Added
+- Recommendation on using explicit imports for future keywords
+
+### Changed
+- Updated all examples to make use of the new future keywords
+
 ## [0.1.0]
 ### Added
 - Initial release


### PR DESCRIPTION
Also, add section recommending explicit imports of future keywords.

Fixes #12 and #13

Signed-off-by: Anders Eknert <anders@eknert.com>