### PR TITLE
Escape gt sign

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,5 @@ deps:
 
 PHONY: toc
 toc: deps
-	markdown-toc -i README.md --bullets="*" --maxdepth=3
+	markdown-toc -i style-guide.md --bullets="*" --maxdepth=3
 

--- a/style-guide.md
+++ b/style-guide.md
@@ -31,7 +31,7 @@ Rego policies. If you enjoy this style guide, make sure to check it out!
   * [Consider using JSON schemas for type checking](#consider-using-json-schemas-for-type-checking)
 * [Style](#style)
   * [Prefer snake_case for rule names and variables](#prefer-snake_case-for-rule-names-and-variables)
-  * [Keep line length <= 120 characters](#keep-line-length--120-characters)
+  * [Keep line length `<=` 120 characters](#keep-line-length--120-characters)
 * [Rules](#rules)
   * [Use helper rules and functions](#use-helper-rules-and-functions)
   * [Use negation to handle undefined](#use-negation-to-handle-undefined)
@@ -220,7 +220,7 @@ Regal rule. Get started with [Regal, the Rego linter](https://docs.styra.com/reg
 :::
 
 
-### Keep line length <= 120 characters
+### Keep line length `<=` 120 characters
 
 Long lines are tedious to read. Keep line length at 120 characters or below.
 


### PR DESCRIPTION
The = character is causing issues where this content is used as mdx, escaping the char in this way seems to be a solution.